### PR TITLE
Add missing DYPlayer settings

### DIFF
--- a/include/MDuinoSound.h
+++ b/include/MDuinoSound.h
@@ -4,6 +4,8 @@
 #include <Arduino.h>
 #include <SendOnlySoftwareSerial.h>
 
+#include "MDuinoStorage.h"
+
 #define DFPLAYER_MAX_CMD    16
 
 /***********************************************************
@@ -88,6 +90,7 @@ class MDuinoSound
 
     protected:
         byte CurrentVolume = 0;
+        MDuinoStorage Storage;
 };
 
 class MDuinoSoundMP3Trigger : public MDuinoSound

--- a/src/MDuinoBase.cpp
+++ b/src/MDuinoBase.cpp
@@ -375,7 +375,8 @@ void MDuinoBase::processSetupCommand(const char* command)
             Storage.setMP3Player(MDuinoStorage::DFPlayer);
         else if (param_num == 2)
             Storage.setMP3Player(MDuinoStorage::Vocalizer);
-                    
+        else if (param_num == 3)
+            Storage.setMP3Player(MDuinoStorage::DYPlayer);
         delay(500);
         resetFunc();
     }

--- a/src/MDuinoSound.cpp
+++ b/src/MDuinoSound.cpp
@@ -12,7 +12,22 @@ void MDuinoSound::VolumeStandard()
 void MDuinoSound::Play(const byte BankNr, const byte SoundNr)
 {
 	byte CalcSoundNr = 0;
-	CalcSoundNr = (BankNr - 1) * 25 + SoundNr;
+
+	switch (Storage.getMP3Player())
+	{
+	case MDuinoStorage::MDuinoMP3PlayerType::DYPlayer:
+		// DYPlayer plays songs by disk index, not by name. We need to calculate the index from bank and sound number.
+		// Files must be properly sorted on the SD card for this to work - use DriveSort or similar.
+		for (uint8_t i = 1; i < BankNr; i++)
+			CalcSoundNr += Storage.getMaxSound(i);
+		CalcSoundNr += SoundNr;
+		break;
+
+	default:
+		CalcSoundNr = (BankNr - 1) * 25 + SoundNr;
+		break;
+	}
+
 	Play(CalcSoundNr);
 }
 


### PR DESCRIPTION
DYPlayer was missing from the #MP command - added.

DYPlayer does not have the option to play a song based on the number in the first three chars of the filename like the SparkFun MP3 trigger, so I added a function to calculate the file index number of a song based on the number of songs in each 'bank'.
The files on the SD card must be sorted properly - I did this with DriveSort.

Tested on my R2 with a DY-SV5W player hooked up to a MarcDuino 1.5.2 board. 

Thanks for your great work on this!